### PR TITLE
Add text shadow and outline features

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,3 +55,10 @@ This will invoke the lambda function locally and generate an `outputs/output-gen
             *   `fontSize`: The size of the font.
             *   `color`: The color of the text.
             *   `rotation`: The rotation of the text.
+            *   `strokeColor`: Optional. Outline color of the text.
+            *   `strokeWidth`: Optional. Outline width in pixels.
+            *   `shadow`: Optional. Apply a shadow behind the text. It is an object with:
+                *   `color`: Shadow color.
+                *   `offsetX`: Horizontal offset relative to the text.
+                *   `offsetY`: Vertical offset relative to the text.
+                *   `blur`: Blur radius for the shadow.

--- a/tests/text-effects-example.js
+++ b/tests/text-effects-example.js
@@ -1,0 +1,39 @@
+import fs from 'fs';
+import GenericGenerator from '../generators/generic.js';
+
+async function run() {
+  const generator = new GenericGenerator({
+    imageWidth: 400,
+    imageHeight: 200,
+    elements: [
+      {
+        id: 'outline-text',
+        type: 'text',
+        text: 'Outlined',
+        fontFamily: 'Arial',
+        fontSize: '40px',
+        color: '#ffffff',
+        strokeColor: '#ff0000',
+        strokeWidth: 3,
+        x: 20,
+        y: 60
+      },
+      {
+        id: 'shadow-text',
+        type: 'text',
+        text: 'Shadow',
+        fontFamily: 'Arial',
+        fontSize: '40px',
+        color: '#000000',
+        shadow: { color: '#888888', offsetX: 4, offsetY: 4, blur: 3 },
+        x: 20,
+        y: 130
+      }
+    ]
+  });
+
+  const buffer = await generator.createImage();
+  fs.writeFileSync('./outputs/output-text-effects.png', buffer);
+}
+
+run().catch(err => console.error(err));


### PR DESCRIPTION
## Summary
- document new text outline & shadow options
- support stroke and shadow rendering for text elements
- add example demonstrating text outlines and shadows

## Testing
- `node --check generators/base.js`
- `node --check generators/generic.js`
- `node --check tests/text-effects-example.js`
- `node tests/text-effects-example.js` *(fails: Cannot find package 'sharp')*

------
https://chatgpt.com/codex/tasks/task_e_685157a22fdc832589fbfa6e79767a80